### PR TITLE
constrain cryptocipher < 0.4.0

### DIFF
--- a/clientsession.cabal
+++ b/clientsession.cabal
@@ -40,7 +40,7 @@ test-suite runtests
     type: exitcode-stdio-1.0
     build-depends:   base
                    , bytestring          >= 0.9
-                   , cryptocipher        >= 0.2.5
+                   , cryptocipher        >= 0.2.5      && < 0.4.0
                    , hspec               >= 1.3
                    , QuickCheck          >= 2
                    , HUnit


### PR DESCRIPTION
cryptocipher 0.4.0 re-exports from the new(?) package cipher-aes which
breaks API compatibility resulting in: "Not in scope: type constructor
 or class `A.AES256'"
