### PR TITLE
Update for cprng-aes 0.5.0

### DIFF
--- a/clientsession.cabal
+++ b/clientsession.cabal
@@ -32,6 +32,7 @@ library
                    , entropy             >= 0.2.1
                    , cprng-aes           >= 0.2
                    , cipher-aes          >= 0.1.7
+                   , crypto-random       >= 0.0.4
     exposed-modules: Web.ClientSession
     ghc-options:     -Wall
     hs-source-dirs:  src


### PR DESCRIPTION
A new version of cprng-aes has been released, hiding `genRandomBytes`. This fixes it, albeit hackily, since `crypto-api` and `crypto-random` both have `Crypto.Random`.

`crypto-random` is not a new dependency, since `cprng-aes` depends on it already.
