### PR TITLE
Avoid declaring source files as runtime data files

### DIFF
--- a/clientsession.cabal
+++ b/clientsession.cabal
@@ -13,8 +13,7 @@ stability:       stable
 cabal-version:   >= 1.8
 build-type:      Simple
 homepage:        http://github.com/yesodweb/clientsession/tree/master
-data-files:      bench.hs
-extra-source-files: tests/runtests.hs
+extra-source-files: tests/runtests.hs bench.hs
 
 flag test
   description: Build the executable to run unit tests


### PR DESCRIPTION
`bench.hs` is not required as a runtime data file.
