### PR TITLE
Use URL-safe Base64

### DIFF
--- a/src/Web/ClientSession.hs
+++ b/src/Web/ClientSession.hs
@@ -82,7 +82,7 @@ import System.Directory (doesFileExist)
 -- from bytestring
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as C
-import qualified Data.ByteString.Base64 as B
+import qualified Data.ByteString.Base64.URL as B
 
 -- from cereal
 import Data.Serialize (encode, Serialize (put, get), getBytes, putByteString)


### PR DESCRIPTION
I'm using this library to implement OAuth2 authorization server (particularly, my access tokens, refresh tokens and codes are all just encrypted JSONs with IDs, wrapped into different records for results to not be interchangeable). Some of them are required to be sent and received over URLs, so the result needs to be URL-safe. As a workaround for now I just convert into URL-safe Base64 before sending to client (and re-convert back when receiving). This commit changes used Base64 encoding to be URL safe. This should break existing sessions for people and I don't know how bad can this impact be. However, I think this is a good use-case for this library and it should be URL-safe out of the box.