### PR TITLE
Migrate crypto-aes and cprng-aes to cryptonite.

### DIFF
--- a/clientsession.cabal
+++ b/clientsession.cabal
@@ -36,9 +36,7 @@ library
                    , skein               == 1.0.*
                    , base64-bytestring   >= 0.1.1.1
                    , entropy             >= 0.2.1
-                   , cprng-aes           >= 0.2
-                   , cipher-aes          >= 0.1.7
-                   , crypto-random
+                   , cryptonite          >= 0.15
                    , setenv
     exposed-modules: Web.ClientSession
     other-modules:   System.LookupEnv


### PR DESCRIPTION
`crypto-aes`'s encryption now fails on my machine with Illegal Instruction errors, and the package has been deprecated in favor of `cryptonite` for years, so migrate to that.

`cprng-aes` is an indirect dependency on `crypto-aes`.  `cryptonite` doesn't offer an AES-based CPRNG, but its ChaCha-based one has the closest interface, so I used that.

The former code has a comment L308 (patched file line numbers) regarding RNG performance. I do not know the referenced benchmark's whereabouts, so I'm delegating that to someone in the know (or signalling for clean-up).

stack (or ghc or cabal) failed to build at stack.yaml's specified lts-6.6, so I tested on lts-19.29.